### PR TITLE
fix: negate disabled check

### DIFF
--- a/example/src/build/index.js
+++ b/example/src/build/index.js
@@ -169,7 +169,7 @@ var ScrollSync = function (props) {
     return (React.createElement(ScrollingSyncerContext.Provider, { value: {
             registerNode: registerNode,
             unregisterNode: unregisterNode,
-            onScroll: function (e, groups) { return props.disabled && handleNodeScroll(e.currentTarget, groups); },
+            onScroll: function (e, groups) { return !props.disabled && handleNodeScroll(e.currentTarget, groups); },
         } }, React.Children.only(props.children)));
 };
 ScrollSync.defaultProps = {

--- a/src/components/ScrollSync/ScrollSync.tsx
+++ b/src/components/ScrollSync/ScrollSync.tsx
@@ -203,7 +203,7 @@ export const ScrollSync: FC<ScrollSyncProps> = props => {
       value={{
         registerNode,
         unregisterNode,
-        onScroll: (e, groups) => props.disabled && handleNodeScroll(e.currentTarget, groups),
+        onScroll: (e, groups) => !props.disabled && handleNodeScroll(e.currentTarget, groups),
       }}
     >
       {React.Children.only(props.children)}


### PR DESCRIPTION
It seems that the check for `disabled` was not considered in this [commit](https://github.com/AhmadMHawwash/scroll-sync-react/commit/145fccfba629abe4ddf9a2212bc3b6d0958edc5f). Thus, currently you have to set `disabled` to true so it works.
