### PR TITLE
Render props

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import AsRenderPropsExample from './Components/AsRenderPropsExample';
 
 import HorizontalExample from './Components/HorizontalExample';
 import VerticalExample from './Components/VerticalExample';
@@ -13,6 +14,8 @@ class App extends Component {
         <HorizontalExample />
         <br />
         <VerticalHorizontalExample />
+        <br />
+        <AsRenderPropsExample />
       </>
     );
   }

--- a/example/src/Components/AsRenderPropsExample.tsx
+++ b/example/src/Components/AsRenderPropsExample.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { ScrollSync, ScrollSyncNode } from '../build';
+import { Banner } from './Banner';
+
+export const AsRenderPropsExample = () => {
+  return (
+    <ScrollSync proportional={false}>
+      <div style={{ display: 'flex', position: 'relative', height: 300 }}>
+        <Banner title="Render Props Example" />
+        <ScrollSyncNode
+          group="a"
+          render={props => {
+            return (
+              <div style={{ overflow: 'auto' }} id="some+id" {...props}>
+                <section style={{ height: 1500 }}>
+                  <h1>This is group `a`</h1>
+                  <p>
+                    Ahmad Hawwash Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab aperiam doloribus dolorum
+                    est eum eveniet exercitationem iste labore minus, neque nobis odit officiis omnis possimus quasi
+                    rerum sed soluta veritatis.
+                  </p>
+                </section>
+              </div>
+            );
+          }}
+        />
+
+        <ScrollSyncNode
+          group="a"
+          render={props => {
+            return (
+              <div style={{ overflow: 'auto' }} {...props}>
+                <section style={{ height: 1000 }}>
+                  <h1>This is group `a`</h1>
+                  <p>
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab aperiam doloribus dolorum est eum
+                    eveniet exercitationem iste labore minus, neque nobis odit officiis omnis possimus quasi rerum sed
+                    soluta veritatis.
+                  </p>
+                </section>
+              </div>
+            );
+          }}
+        />
+      </div>
+    </ScrollSync>
+  );
+};
+
+export default AsRenderPropsExample;

--- a/example/src/build/components/ScrollSync/ScrollSyncNode.d.ts
+++ b/example/src/build/components/ScrollSync/ScrollSyncNode.d.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { JSXElementConstructor, ReactElement } from "react";
 /**
  * ScrollSyncNode Component
  *
@@ -6,11 +6,16 @@ import React from "react";
  */
 export declare type ScrollConfig = "synced-only" | "syncer-only" | "two-way";
 export declare type LockAxis = "X" | "Y" | "XY" | null;
-interface ScrollSyncNodeProps {
+export interface ScrollSyncNodeRenderProps {
+    onScroll: (e: React.UIEvent<any>) => void;
+    onWheel: (e: React.UIEvent<any>) => void;
+    ref: React.MutableRefObject<any>;
+}
+export interface ScrollSyncNodeProps {
     /**
      * Children
      */
-    children: React.ReactElement;
+    children?: React.ReactElement;
     /**
      * Groups to make the children attached to
      */
@@ -27,6 +32,7 @@ interface ScrollSyncNodeProps {
      * Callback for scroll handling
      */
     onScroll?: (e: React.UIEvent<HTMLElement>) => void;
+    render?: (props: ScrollSyncNodeRenderProps) => ReactElement<any, string | JSXElementConstructor<any>> | null;
 }
 declare const ScrollSyncNode: React.ForwardRefExoticComponent<ScrollSyncNodeProps & React.RefAttributes<EventTarget & HTMLElement>>;
 export default ScrollSyncNode;

--- a/example/src/build/index.js
+++ b/example/src/build/index.js
@@ -189,9 +189,10 @@ var getMovingAxis = function (e) {
 };
 
 var ScrollSyncNode = forwardRef(function (props, forwardedRef) {
-    var children = props.children, _a = props.group, group = _a === void 0 ? "default" : _a, _b = props.scroll, scroll = _b === void 0 ? "two-way" : _b, _c = props.selfLockAxis, selfLockAxis = _c === void 0 ? null : _c, _d = props.onScroll, onNodeScroll = _d === void 0 ? function () { return undefined; } : _d;
-    var _e = useContext(ScrollingSyncerContext), registerNode = _e.registerNode, unregisterNode = _e.unregisterNode, onScroll = _e.onScroll;
-    var childRef = children.ref;
+    var _a;
+    var children = props.children, _b = props.group, group = _b === void 0 ? "default" : _b, _c = props.scroll, scroll = _c === void 0 ? "two-way" : _c, _d = props.selfLockAxis, selfLockAxis = _d === void 0 ? null : _d, _e = props.onScroll, onNodeScroll = _e === void 0 ? function () { return undefined; } : _e, render = props.render;
+    var _f = useContext(ScrollingSyncerContext), registerNode = _f.registerNode, unregisterNode = _f.unregisterNode, onScroll = _f.onScroll;
+    var childRef = (_a = children) === null || _a === void 0 ? void 0 : _a.ref;
     var hasDoubleRef = childRef != null && forwardedRef != null;
     if (hasDoubleRef) {
         console.warn("scroll-sync-react:\nWARNING: ref used on both ScrollSyncNode and its direct child.\nUsing the ref from the ScrollSyncNode component.");
@@ -234,28 +235,35 @@ var ScrollSyncNode = forwardRef(function (props, forwardedRef) {
     }, [scroll, group]);
     var isSyncer = scroll === "syncer-only";
     var isEnabled = scroll === "two-way";
+    var _onScroll = function (e) {
+        if (typeof (children === null || children === void 0 ? void 0 : children.props.onScroll) === "function") {
+            children.props.onScroll(e);
+        }
+        e.persist();
+        if (isSyncer || isEnabled) {
+            onScroll(e, toArray(group));
+            onNodeScroll(e);
+        }
+    };
+    var _onWheel = function (e) {
+        if (typeof (children === null || children === void 0 ? void 0 : children.props.onWheel) === "function") {
+            children.props.onWheel(e);
+        }
+        e.persist();
+        if (isSyncer || isEnabled) {
+            onScroll(e, toArray(group));
+            onNodeScroll(e);
+        }
+    };
+    if (render) {
+        return render({ ref: ref, onScroll: _onScroll, onWheel: _onWheel });
+    }
+    if (!children)
+        throw new Error("Children can not be undefined if render prop has not bee passed");
     return React.cloneElement(children, {
         ref: ref,
-        onScroll: function (e) {
-            if (typeof children.props.onScroll === "function") {
-                children.props.onScroll(e);
-            }
-            e.persist();
-            if (isSyncer || isEnabled) {
-                onScroll(e, toArray(group));
-                onNodeScroll(e);
-            }
-        },
-        onWheel: function (e) {
-            if (typeof children.props.onWheel === "function") {
-                children.props.onWheel(e);
-            }
-            e.persist();
-            if (isSyncer || isEnabled) {
-                onScroll(e, toArray(group));
-                onNodeScroll(e);
-            }
-        },
+        onScroll: _onScroll,
+        onWheel: _onWheel,
     });
 });
 ScrollSyncNode.displayName = "ScrollSyncNode";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scroll-sync-react",
-  "version": "1.1.8",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This is related to #15 and is more of a proof of concept than anything else. Using a render slot may not be the best way to do this, but it's a good place to start. I would prefer to use a `fowardRef` and pass that directly to the scroll component like so:

```
const MyCustomComponent = React.forwardRef(( _props, ref ) => {
  return (
    <div id="outer">
        <div id="inner" ref={ref}></div>
    </div>
  )
})

<ScrollSyncNode component={MyCustomComponent} /> 
```

However, I am working on an example for the above, until then we have this.

Having the `render` prop allows the developer to decide which element we want to store a ref for, I have included an example so you can can clone or add my fork remote to your existing project and see what you think.

I am aware this breaks some existing functionality and the typings are poor, I didn't spend to much time on it.