### PR TITLE
Sync new node scroll positions with existing ones when initially added

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 
 import HorizontalExample from './Components/HorizontalExample';
+import InitialSyncExample from './Components/InitialSyncExample';
 import VerticalExample from './Components/VerticalExample';
 import VerticalHorizontalExample from './Components/VerticalHorizontalExample';
 
@@ -13,6 +14,8 @@ class App extends Component {
         <HorizontalExample />
         <br />
         <VerticalHorizontalExample />
+        <br />
+        <InitialSyncExample />
       </>
     );
   }

--- a/example/src/Components/InitialSyncExample.tsx
+++ b/example/src/Components/InitialSyncExample.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { ScrollSync, ScrollSyncNode } from '../build';
+import { Banner } from './Banner';
+
+export const InitialSyncExample = () => {
+  const [elements, setElements] = useState(1);
+
+  return (
+    <>
+      <Banner title="Sync New Elements Examples" />
+      <ScrollSync>
+        <div style={{ display: 'flex', position: 'relative', height: 300 }}>
+          {[...new Array(elements)].map((_, idx) => (
+            <ScrollSyncNode key={idx} group="Synced">
+              <div style={{ overflow: 'auto' }}>
+                <section style={{ height: 1000 }}>
+                  <h1>This is group `Synced`</h1>
+                  <p>
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab aperiam doloribus dolorum est eum
+                    eveniet exercitationem iste labore minus, neque nobis odit officiis omnis possimus quasi rerum sed
+                    soluta veritatis.
+                  </p>
+                </section>
+              </div>
+            </ScrollSyncNode>
+          ))}
+        </div>
+      </ScrollSync>
+      <button onClick={() => setElements(elements + 2)}>Add two more boxes</button>
+    </>
+  );
+};
+
+export default InitialSyncExample;

--- a/src/components/ScrollSync/ScrollSync.tsx
+++ b/src/components/ScrollSync/ScrollSync.tsx
@@ -111,6 +111,11 @@ export const ScrollSync: FC<ScrollSyncProps> = props => {
         elements[group] = [];
       }
 
+      const existingElement = elements[group][0];
+      if (existingElement) {
+        syncScrollPosition(existingElement.node, element.node)
+      }
+
       elements[group].push({ ...element });
     });
   };


### PR DESCRIPTION
**Problem:**
Currently if you add a new ScrollSyncNode to an existing group, there is no mechanism to sync the scroll position for the newly added element until after the user scrolls any of the nodes manually.

**Proposed solution:**
When a new node is registered, if there is an existing node in the group, trigger a scroll sync between the existing node and the new one. This causes the new node to be synced as if the user moved the scrollbar.

The choice of the first node to sync against is arbitrary, as all existing nodes should be synced and the result should be the same no matter which node is synced against. (At least to my knowledge, only caveat is if using non-proportional scrolls with different sizes which cannot be handled consistently  in any case)


There is an example showing the behaviour in the InitialSyncExample component.